### PR TITLE
Update diagnostics.py

### DIFF
--- a/cvtk/diagnostics.py
+++ b/cvtk/diagnostics.py
@@ -27,8 +27,8 @@ def calc_diagnostics(covs, mean_hets, seqids, tile_depths,
     # but we return the *full* dataframe, which we make a
     # copy of here.
     full_df = df
-    with pd.option_context('mode.use_inf_as_null', True):
-        df = df.dropna()
+    df.replace([np.inf, -np.inf], np.nan, inplace=True)
+    df = df.dropna()
     if exclude_seqids is not None:
         df = df[~df.seqid.isin(exclude_seqids)]
     diag_fit = smf.ols("diag ~ depth", df).fit()


### PR DESCRIPTION
When calling `calc_diagnostics` I got the following error:

```
Traceback (most recent call last):
  File "/home/pascal/bioinformatics/cvtkpy/test.py", line 72, in <module>
    diagnostics = d.correction_diagnostics(exclude_seqids=['X'], use_masked=True, offdiag_k=1, depth_limits=(30, 120))
  File "/home/pascal/bioinformatics/cvtkpy/cvtk/cvtk.py", line 305, in correction_diagnostics
    res = calc_diagnostics(covs, mean_hets, seqids, tile_depths,
  File "/home/pascal/bioinformatics/cvtkpy/cvtk/diagnostics.py", line 30, in calc_diagnostics
    with pd.option_context('mode.use_inf_as_null', True):
  File "/home/pascal/miniconda3/envs/cvtkpy/lib/python3.10/site-packages/pandas-2.0.3-py3.10-linux-x86_64.egg/pandas/_config/config.py", line 441, in __enter__
    self.undo = [(pat, _get_option(pat, silent=True)) for pat, val in self.ops]
  File "/home/pascal/miniconda3/envs/cvtkpy/lib/python3.10/site-packages/pandas-2.0.3-py3.10-linux-x86_64.egg/pandas/_config/config.py", line 441, in <listcomp>
    self.undo = [(pat, _get_option(pat, silent=True)) for pat, val in self.ops]
  File "/home/pascal/miniconda3/envs/cvtkpy/lib/python3.10/site-packages/pandas-2.0.3-py3.10-linux-x86_64.egg/pandas/_config/config.py", line 135, in _get_option
    key = _get_single_key(pat, silent)
  File "/home/pascal/miniconda3/envs/cvtkpy/lib/python3.10/site-packages/pandas-2.0.3-py3.10-linux-x86_64.egg/pandas/_config/config.py", line 121, in _get_single_key
    raise OptionError(f"No such keys(s): {repr(pat)}")
pandas._config.config.OptionError: No such keys(s): 'mode.use_inf_as_null'
```

It seems `'mode.use_inf_as_null'` has been removed from `pd.option_context()`. `df.replace([np.inf, -np.inf], np.nan, inplace=True)` is my suggestion to replace it.